### PR TITLE
URIEncodingFilter

### DIFF
--- a/siren-core/src/main/java/org/sindice/siren/analysis/filter/URIEncodingFilter.java
+++ b/siren-core/src/main/java/org/sindice/siren/analysis/filter/URIEncodingFilter.java
@@ -38,7 +38,7 @@ import org.sindice.siren.analysis.TupleTokenizer;
 
 /**
  * Decode the URI encoding format of special characters such as '?' or '<'; special
- * characters (excepth of the SPACE that can be encoded with '+') begins with a '%'
+ * characters (except of the SPACE that can be encoded with '+') begins with a '%'
  * and are followed by two characters in hexadecimal format.
  * if a special character cannot be decoded, it is just skipped and the decoding
  * process just continue.
@@ -282,7 +282,10 @@ public class URIEncodingFilter extends TokenFilter {
 
           // The next two characters converted from a hex to a decimal value
           final int value = this.hexaToInt2(c1) + this.hexaToInt(c2);
-          if (value != 32 && value >= 0) { // Negative value are illegal. Just skip it.
+          if (value == 32) { // replace the SPACE character, encoded by %20, by +
+            decodeChars();
+            termBuffer.put('+');
+          } else if (value >= 0) { // Negative value are illegal. Just skip it.
             if (!decoded.hasRemaining()) { // No more place in the buffer, output what is already there.
               decodeChars();
             }

--- a/siren-core/src/main/java/org/sindice/siren/analysis/filter/URIEncodingFilter.java
+++ b/siren-core/src/main/java/org/sindice/siren/analysis/filter/URIEncodingFilter.java
@@ -1,0 +1,322 @@
+/**
+ * Copyright 2011, Campinas Stephane
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * @project siren-core
+ * @author Campinas Stephane [ 19 May 2011 ]
+ * @link stephane.campinas@deri.org
+ */
+package org.sindice.siren.analysis.filter;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.UnsupportedCharsetException;
+
+import org.apache.lucene.analysis.TokenFilter;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
+import org.apache.lucene.analysis.tokenattributes.TypeAttribute;
+import org.sindice.siren.analysis.TupleTokenizer;
+
+/**
+ * Decode the URI encoding format of special characters such as '?' or '<'; special
+ * characters (excepth of the SPACE that can be encoded with '+') begins with a '%'
+ * and are followed by two characters in hexadecimal format.
+ * if a special character cannot be decoded, it is just skipped and the decoding
+ * process just continue.
+ * When an URI has special characters, two stems of the URI are produced
+ * (both terms have the same position):
+ * <ul>
+ * <li> the original URI </li>
+ * <li> the decoded URI </li>
+ * </ul>
+ */
+public class URIEncodingFilter extends TokenFilter {
+
+  private final CharsetDecoder    charsetDecoder;
+  private final ByteBuffer        decoded = ByteBuffer.allocate(32);
+
+  private boolean                 modifiedURI = false;
+  private CharBuffer              termBuffer;
+  private int                     termLength;
+
+  private final CharTermAttribute           termAtt;
+  private final TypeAttribute               typeAtt;
+  private final PositionIncrementAttribute  posIncrAtt;
+
+  /**
+   *
+   * @param input
+   * @param encoding the name of a supported <a href="../lang/package-summary.html#charenc">character encoding</a>.
+   * @throws UnsupportedCharsetException if the character encoding is not supported or recognised.
+   */
+  public URIEncodingFilter(final TokenStream input, final String encoding)
+  throws UnsupportedCharsetException {
+    super(input);
+    final Charset charset = this.lookupCharset(encoding);
+    charsetDecoder = charset.newDecoder()
+                            .onMalformedInput(CodingErrorAction.REPLACE)
+                            .onUnmappableCharacter(CodingErrorAction.REPLACE);
+    termAtt = this.addAttribute(CharTermAttribute.class);
+    typeAtt = this.addAttribute(TypeAttribute.class);
+    posIncrAtt = this.addAttribute(PositionIncrementAttribute.class);
+    termBuffer = CharBuffer.allocate(256);
+  }
+
+  @Override
+  public final boolean incrementToken()
+  throws IOException {
+    if (modifiedURI) { // Return the previously decoded URI
+      modifiedURI = false;
+      termAtt.setEmpty();
+      termAtt.copyBuffer(termBuffer.array(), 0, termBuffer.position());
+      posIncrAtt.setPositionIncrement(0);
+      return true;
+    }
+
+    if (input.incrementToken()) {
+      final String type = typeAtt.type();
+      if (type.equals(TupleTokenizer.getTokenTypes()[TupleTokenizer.URI])) {
+        termLength = termAtt.length();
+        this.updateBuffer();
+        this.decode();
+      }
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Check if the buffer is big enough
+   */
+  private void updateBuffer() {
+    final int newTermLength = termLength >> 1;
+
+    if (termBuffer.capacity() < termLength && termBuffer.capacity() < newTermLength) {
+      termBuffer = CharBuffer.allocate(termLength > 500 ? newTermLength : termLength);
+    }
+    termBuffer.clear();
+  }
+
+  /**
+   * look for the class of the given charset
+   * @param csn
+   * @return
+   * @throws UnsupportedCharsetException
+   */
+  private Charset lookupCharset(final String csn)
+  throws UnsupportedCharsetException {
+    if (Charset.isSupported(csn)) {
+      return Charset.forName(csn);
+    }
+    throw new UnsupportedCharsetException(csn);
+  }
+
+  /**
+   * Return the decimal value of an hexadecimal number. If it is not hexadecimal,
+   * a negative value is returned.
+   * @param c
+   * @return
+   */
+  private int hexaToInt(final char c) {
+    switch (c) {
+      case '0':
+        return 0;
+      case '1':
+        return 1;
+      case '2':
+        return 2;
+      case '3':
+        return 3;
+      case '4':
+        return 4;
+      case '5':
+        return 5;
+      case '6':
+        return 6;
+      case '7':
+        return 7;
+      case '8':
+        return 8;
+      case '9':
+        return 9;
+      case 'a':
+        return 10;
+      case 'b':
+        return 11;
+      case 'c':
+        return 12;
+      case 'd':
+        return 13;
+      case 'e':
+        return 14;
+      case 'f':
+        return 15;
+      case 'A':
+        return 10;
+      case 'B':
+        return 11;
+      case 'C':
+        return 12;
+      case 'D':
+        return 13;
+      case 'E':
+        return 14;
+      case 'F':
+        return 15;
+      default:
+        /*
+         * Return a negative value if the hexadecimal character is invalid.
+         * Because it is < 0 and big enough, the character won't be decoded.
+         */
+        return -241;
+    }
+  }
+
+  /**
+   * Return the decimal value of an hexadecimal number, multiplied by 16.
+   * If it is not hexadecimal, a negative value is returned.
+   * @param c
+   * @return
+   */
+  private int hexaToInt2(final char c) {
+    switch (c) {
+      case '0':
+        return 0;
+      case '1':
+        return 16;
+      case '2':
+        return 32;
+      case '3':
+        return 48;
+      case '4':
+        return 64;
+      case '5':
+        return 80;
+      case '6':
+        return 96;
+      case '7':
+        return 112;
+      case '8':
+        return 128;
+      case '9':
+        return 144;
+      case 'a':
+        return 160;
+      case 'b':
+        return 176;
+      case 'c':
+        return 192;
+      case 'd':
+        return 208;
+      case 'e':
+        return 224;
+      case 'f':
+        return 240;
+      case 'A':
+        return 160;
+      case 'B':
+        return 176;
+      case 'C':
+        return 192;
+      case 'D':
+        return 208;
+      case 'E':
+        return 224;
+      case 'F':
+        return 240;
+      default:
+        /*
+         * Return a negative value if the hexadecimal character is invalid.
+         * Because it is < 0 and big enough, the character won't be decoded.
+         */
+        return -241;
+    }
+  }
+
+  /**
+   * Partial decoding of URI encoded characters.
+   * <br>
+   * Ignore the '+' and %20 (i.e., 32 in decimal) (SPACE) cases, as it does not
+   * make sense to index URIs with a space. Nobody will be able to search them
+   * as a space will be considered as a character delimitation.
+   */
+  private void decode() {
+    char c;
+    int i = 0;
+
+    while (i < termLength) {
+      c = termAtt.charAt(i);
+      switch (c) {
+      case '%': // Special character
+        /*
+         * Starting with this instance of %, process all consecutive substrings
+         * of the form %xy. Each substring %xy will yield a byte. Convert all
+         * consecutive  bytes obtained this way to whatever character(s) they
+         * represent in the provided encoding.
+         *
+         * xy is a hexadecimal number.
+         */
+        modifiedURI = true;
+        while (i + 2 < termLength && c == '%') {
+          final char c1 = termAtt.charAt(i + 1);
+          final char c2 = termAtt.charAt(i + 2);
+
+          // The next two characters converted from a hex to a decimal value
+          final int value = this.hexaToInt2(c1) + this.hexaToInt(c2);
+          if (value != 32 && value >= 0) { // Negative value are illegal. Just skip it.
+            if (!decoded.hasRemaining()) { // No more place in the buffer, output what is already there.
+              decodeChars();
+            }
+            decoded.put((byte) value);
+          } else { // put the value back, without changing it
+            decodeChars();
+            termBuffer.put('%').put(c1).put(c2);
+          }
+          i += 3;
+          if (i < termLength)
+            c = termAtt.charAt(i);
+        }
+        // decode the chain of special characters
+        decodeChars();
+        // incomplete byte encoding (e.g., %x). Skip it.
+        if (i < termLength && c == '%') {
+          termBuffer.put('%');
+          i++;
+        }
+        break;
+      default:
+        termBuffer.put(c);
+        i++;
+        break;
+      }
+    }
+  }
+  
+  private void decodeChars() {
+    final int limit = decoded.position();
+    decoded.position(0);
+    decoded.limit(limit);
+    charsetDecoder.decode(decoded, termBuffer, true);
+    decoded.clear();
+  }
+
+}

--- a/siren-core/src/test/java/org/sindice/siren/analysis/filter/TestURIEncodingFilter.java
+++ b/siren-core/src/test/java/org/sindice/siren/analysis/filter/TestURIEncodingFilter.java
@@ -1,0 +1,220 @@
+/**
+ * Copyright 2011, Campinas Stephane
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * @project siren-core
+ * @author Campinas Stephane [ 19 May 2011 ]
+ * @link stephane.campinas@deri.org
+ */
+package org.sindice.siren.analysis.filter;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.UnsupportedCharsetException;
+
+import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.analysis.WhitespaceAnalyzer;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
+import org.apache.lucene.analysis.tokenattributes.TypeAttribute;
+import org.apache.lucene.util.Version;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.sindice.siren.analysis.TupleTokenizer;
+
+/**
+ *
+ */
+public class TestURIEncodingFilter {
+
+  private final String uritype = TupleTokenizer.getTokenTypes()[TupleTokenizer.URI];
+  private final String defaulttype = TypeAttribute.DEFAULT_TYPE;
+
+  private final Tokenizer _t = new TupleTokenizer(new StringReader(""),
+    Integer.MAX_VALUE, new WhitespaceAnalyzer(Version.LUCENE_31));
+
+  /**
+   * @throws java.lang.Exception
+   */
+  @Before
+  public void setUp()
+  throws Exception {}
+
+  /**
+   * @throws java.lang.Exception
+   */
+  @After
+  public void tearDown()
+  throws Exception {}
+
+  /*
+   * Helpers
+   */
+
+  private void assertURLDecodedTo(final Tokenizer t, final String uri, final String[] expectedStems)
+  throws IOException {
+    this.assertURLDecodedTo(t, "UTF-8", uri, expectedStems, null, null);
+  }
+
+  private void assertURLDecodedTo(final Tokenizer t, final String encoding, final String uri, final String[] expectedStems)
+  throws IOException {
+    this.assertURLDecodedTo(t, encoding, uri, expectedStems, null, null);
+  }
+
+  private void assertURLDecodedTo(final Tokenizer t, final String uri, final String[] expectedStems, final String[] expectedTypes, final int[] expectedPosIncr)
+  throws IOException {
+    this.assertURLDecodedTo(t, "UTF-8", uri, expectedStems, expectedTypes, expectedPosIncr);
+  }
+
+  private void assertURLDecodedTo(final Tokenizer t, final String encoding, final String uri, final String[] expectedStems, final String[] expectedTypes, final int[] expectedPosIncr)
+  throws IOException {
+    assertTrue("has CharTermAttribute", t.hasAttribute(CharTermAttribute.class));
+    final CharTermAttribute termAtt = t.getAttribute(CharTermAttribute.class);
+
+    assertTrue("has TypeAttribute", t.hasAttribute(TypeAttribute.class));
+    final TypeAttribute typeAtt = t.getAttribute(TypeAttribute.class);
+
+    assertTrue("has PositionIncrementAttribute", t.hasAttribute(PositionIncrementAttribute.class));
+    final PositionIncrementAttribute posIncrAtt = t.getAttribute(PositionIncrementAttribute.class);
+
+    t.reset(new StringReader(uri));
+    final URIEncodingFilter filter = new URIEncodingFilter(t, encoding);
+    for (int i = 0; i < expectedStems.length; i++) {
+        assertTrue("token " + i + " exists", filter.incrementToken());
+        assertEquals(expectedStems[i], termAtt.toString());
+        if (expectedTypes == null)
+          assertEquals(uritype, typeAtt.type());
+        else
+          assertEquals(expectedTypes[i], typeAtt.type());
+        if (expectedPosIncr != null)
+          assertEquals(expectedPosIncr[i], posIncrAtt.getPositionIncrement());
+    }
+    filter.end();
+  }
+
+  /**
+   * Check if an URI with no URL encoded characters is left as it is
+   * @throws Exception
+   */
+  @Test
+  public void testNoURLEncodedCharacters()
+  throws Exception {
+    this.assertURLDecodedTo(_t, "<http://stephane.net>", new String[] { "http://stephane.net" });
+  }
+
+  /**
+   * Check if special characters are correctly decoded and if the filters produces the two stems of the URI
+   * @throws Exception
+   */
+  @Test
+  public void testSpecialcharacters()
+  throws Exception {
+    this.assertURLDecodedTo(_t, "<http://stephane.net/%32%21Space%21space>",
+      new String[] { "http://stephane.net/%32%21Space%21space", "http://stephane.net/2!Space!space" });
+    this.assertURLDecodedTo(_t, "<http://stephane.net/%57%68%4F%61%72%65%79%6f%75%3F>",
+      new String[] { "http://stephane.net/%57%68%4F%61%72%65%79%6f%75%3F", "http://stephane.net/WhOareyou?" });
+    // We does not decode space
+    this.assertURLDecodedTo(_t, "<http://stephane.net/%57%68%4F+%61%72%65+%79%6f%75%20%3F>",
+      new String[] { "http://stephane.net/%57%68%4F+%61%72%65+%79%6f%75%20%3F", "http://stephane.net/WhO+are+you%20?" });
+  }
+
+  /**
+   * Check if the boundaries of the internal buffers are correct.
+   * @throws Exception
+   */
+  @Test
+  public void testLongURLEncodedChain()
+  throws Exception {
+    this.assertURLDecodedTo(_t, "<deus%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40>",
+      new String[] { "deus%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40",
+                     "deus@@@@@@@@@@@@@@@@@@@@" });
+    this.assertURLDecodedTo(_t, "<deus%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40+%3f>",
+      new String[] { "deus%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40%40+%3f",
+                     "deus@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@+?" });
+    final String looong = "%20%21%22%23%24%25%26%27%28%29%2a%2b%2c%2d%2e%2f%30" +
+    		"%31%32%33%34%35%36%37%38%39%3a%3b%3c%3d%3e%3f%40%41%42%43%44%45%46%47" +
+    		"%48%49%4a%4b%4c%4d%4e%4f%50%51%52%53%54%55%56%57%58%59%5a%5b%5c%5d%5e" +
+    		"%5f%60%61%62%63%64%65%66%67%68%69%6a%6b%6c%6d%6e%6f%70%71%72%73%74%75" +
+    		"%76%77%78%79%7a%7b%7c%7d%7e";
+    final String decLooong = "%20!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOP" +
+    		"QRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~";
+    this.assertURLDecodedTo(_t, "<" + looong + looong + looong + looong + ">",
+      new String[]{ looong + looong + looong + looong,
+                    decLooong + decLooong + decLooong + decLooong });
+    this.assertURLDecodedTo(_t, "<" + looong + looong + looong + looong + looong + looong + looong + looong + ">",
+      new String[]{ looong + looong + looong + looong + looong + looong + looong + looong,
+                    decLooong + decLooong + decLooong + decLooong + decLooong + decLooong + decLooong + decLooong });
+  }
+
+  /**
+   * Check that badly encoded URL characters are left as they are. The decoding continue
+   * nonetheless on the rest of the URI
+   * @throws Exception
+   */
+  @Test
+  public void testWronglyEncodedCharacters()
+  throws Exception {
+    this.assertURLDecodedTo(_t, "<http://stephane.net/%>",
+      new String[] { "http://stephane.net/%", "http://stephane.net/%" });
+    this.assertURLDecodedTo(_t, "<http://stephane.net/%8>",
+      new String[] { "http://stephane.net/%8", "http://stephane.net/%8" });
+    this.assertURLDecodedTo(_t, "<http://stephane.net/%%3f>",
+      new String[] { "http://stephane.net/%%3f", "http://stephane.net/%%3f" });
+    this.assertURLDecodedTo(_t, "<http://stephane.net/%GGporco>",
+      new String[] { "http://stephane.net/%GGporco", "http://stephane.net/%GGporco" });
+    this.assertURLDecodedTo(_t, "<http://stephane.net/%G3porco%2erosso>",
+      new String[] { "http://stephane.net/%G3porco%2erosso", "http://stephane.net/%G3porco.rosso" });
+  }
+
+  /**
+   * Test bad Charset name
+   * @throws Exception
+   */
+  @Test(expected=UnsupportedCharsetException.class)
+  public void testUnsupportedCharset()
+  throws Exception {
+    this.assertURLDecodedTo(_t, "FTU_8", "", new String[] {});
+  }
+
+  /**
+   * Test where {@link URIEncodingFilter#hexaToInt} return a negative value
+   * @throws Exception
+   */
+  @Test
+  public void testBadHexadecimalNumber()
+  throws Exception {
+    this.assertURLDecodedTo(_t, "<http://stephane%3f%FGnet/>", new String[] { "http://stephane%3f%FGnet/", "http://stephane?%FGnet/" });
+  }
+
+  /**
+   * Test a sequence of tokens with different types.
+   * @throws Exception
+   */
+  @Test
+  public void testDifferentTypes()
+  throws Exception {
+    this.assertURLDecodedTo(_t, "<stephane%3Fnet/> \"A literal !!!!\" <porco%2erosso>",
+      new String[] { "stephane%3Fnet/", "stephane?net/", "A", "literal", "!!!!", "porco%2erosso", "porco.rosso" },
+      new String[] { uritype, uritype, defaulttype, defaulttype, defaulttype, uritype, uritype },
+      new int[] { 1, 0, 1, 1, 1, 1, 0 });
+  }
+
+}

--- a/siren-core/src/test/java/org/sindice/siren/analysis/filter/TestURIEncodingFilter.java
+++ b/siren-core/src/test/java/org/sindice/siren/analysis/filter/TestURIEncodingFilter.java
@@ -133,7 +133,7 @@ public class TestURIEncodingFilter {
       new String[] { "http://stephane.net/%57%68%4F%61%72%65%79%6f%75%3F", "http://stephane.net/WhOareyou?" });
     // We does not decode space
     this.assertURLDecodedTo(_t, "<http://stephane.net/%57%68%4F+%61%72%65+%79%6f%75%20%3F>",
-      new String[] { "http://stephane.net/%57%68%4F+%61%72%65+%79%6f%75%20%3F", "http://stephane.net/WhO+are+you%20?" });
+      new String[] { "http://stephane.net/%57%68%4F+%61%72%65+%79%6f%75%20%3F", "http://stephane.net/WhO+are+you+?" });
   }
 
   /**
@@ -154,7 +154,7 @@ public class TestURIEncodingFilter {
     		"%48%49%4a%4b%4c%4d%4e%4f%50%51%52%53%54%55%56%57%58%59%5a%5b%5c%5d%5e" +
     		"%5f%60%61%62%63%64%65%66%67%68%69%6a%6b%6c%6d%6e%6f%70%71%72%73%74%75" +
     		"%76%77%78%79%7a%7b%7c%7d%7e";
-    final String decLooong = "%20!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOP" +
+    final String decLooong = "+!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOP" +
     		"QRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~";
     this.assertURLDecodedTo(_t, "<" + looong + looong + looong + looong + ">",
       new String[]{ looong + looong + looong + looong,
@@ -217,4 +217,11 @@ public class TestURIEncodingFilter {
       new int[] { 1, 0, 1, 1, 1, 1, 0 });
   }
 
+  @Test
+  public void testSpaces()
+  throws Exception {
+    this.assertURLDecodedTo(_t, "<http://s+t+e%20%20p+h%20+%20ane/>", new String[] { "http://s+t+e%20%20p+h%20+%20ane/",
+                                                                                     "http://s+t+e++p+h+++ane/" });
+  }
+  
 }


### PR DESCRIPTION
corrected bug in the uriencoding filter:
when there is a badly encoded character, the previously decoded characters were skipped
